### PR TITLE
feat: add network layer

### DIFF
--- a/ClassesApp/Network/APIClient.swift
+++ b/ClassesApp/Network/APIClient.swift
@@ -1,0 +1,79 @@
+//
+//  APIClient.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+import Foundation
+
+/// A simple network client for executing HTTP requests.
+/// Currently handles basic REST operations with optional parameters and decoding support.
+///
+/// Improvements that could be made:
+/// - Decouple decoding logic from the request method for better testability and separation of concerns.
+/// - Extend `APIError` to support backend-specific error responses (e.g. decoding error objects returned by the server).
+/// - Support for custom headers, request timeout, retries, or interceptors.
+/// - Add generic logging or monitoring (especially for debugging or analytics).
+final class APIClient {
+
+  /// Singleton instance for shared usage across the app.
+  static let shared = APIClient()
+  private init() {}
+
+  /// Executes a request based on the `Endpoint` configuration.
+  ///
+  /// - Parameter endpoint: An instance conforming to the `Endpoint` protocol, describing method, path, parameters, and response type.
+  /// - Returns: The decoded response of type `E.Response`.
+  /// - Throws: An `APIError` if the request fails at any stage (invalid URL, encoding, decoding, network issues).
+  func request<E: Endpoint>(_ endpoint: E) async throws -> E.Response {
+    var urlComponents = URLComponents(string: "\(APIClient.basePath)/\(endpoint.path)")
+
+    if (endpoint.method == .get || endpoint.method == .delete),
+       let parameters = endpoint.parameters {
+      urlComponents?.queryItems = parameters.compactMap { key, value in
+        guard let value = value else { return nil }
+        return URLQueryItem(name: key, value: "\(value)")
+      }
+    }
+
+    guard let url = urlComponents?.url else {
+      throw APIError.invalidURL
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = endpoint.method.rawValue.uppercased()
+
+    if (endpoint.method == .post || endpoint.method == .put),
+       let parameters = endpoint.parameters {
+      do {
+        request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      } catch {
+        throw APIError.encodingFailed(error)
+      }
+    }
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    
+    guard (200...299).contains(httpResponse.statusCode) else {
+      throw APIError.statusCode(httpResponse.statusCode)
+    }
+
+    do {
+      return try JSONDecoder().decode(E.Response.self, from: data)
+    } catch {
+      throw APIError.decodingFailed(error)
+    }
+  }
+}
+
+extension APIClient {
+  static var basePath: String {
+    "http://localhost:4000"
+  }
+}

--- a/ClassesApp/Network/APIError.swift
+++ b/ClassesApp/Network/APIError.swift
@@ -1,0 +1,67 @@
+//
+//  APIError.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+import Foundation
+
+/// Represents common API-level errors thrown by the `APIClient`.
+///
+/// This enum handles validation, encoding/decoding, and basic HTTP error codes.
+///
+/// **Potential Improvements:**
+/// - Add a `.serverError(CustomError)` case to decode backend-specific error objects for more meaningful feedback.
+/// - Include support for networking layer retries or recovery actions.
+/// - Separate error domains (e.g., transport vs. decoding vs. server) more explicitly.
+enum APIError: Error {
+  
+  /// URL creation failed or the path is malformed.
+  case invalidURL
+  
+  /// A request-level failure (e.g., connectivity issue, timeouts).
+  case requestFailed(Error)
+  
+  /// Response received was not a valid `HTTPURLResponse`.
+  case invalidResponse
+  
+  /// Received HTTP status code outside the success range (200–299).
+  case statusCode(Int)
+  
+  /// Failed to decode the response from the server.
+  case decodingFailed(Error)
+  
+  /// Failed to encode the request body into JSON.
+  case encodingFailed(Error)
+
+  /// Human-readable error messages, useful for debugging or UI feedback.
+  var message: String {
+    switch self {
+    case .invalidURL:
+      return "The URL is invalid or malformed."
+      
+    case .requestFailed(let error):
+      return "The request could not be completed: \(error.localizedDescription)"
+      
+    case .invalidResponse:
+      return "The server response was invalid."
+      
+    case .statusCode(let code):
+      switch code {
+      case 400: return "Bad request (400)."
+      case 401: return "Unauthorized access (401)."
+      case 403: return "Forbidden request (403)."
+      case 404: return "Resource not found (404)."
+      case 500: return "Internal server error (500)."
+      default:  return "Unexpected HTTP error: \(code)."
+      }
+      
+    case .decodingFailed(let error):
+      return "Failed to decode the server response: \(error.localizedDescription)"
+      
+    case .encodingFailed(let error):
+      return "Failed to encode the request body: \(error.localizedDescription)"
+    }
+  }
+}

--- a/ClassesApp/Network/Endpoints/Protocols/Endpoint.swift
+++ b/ClassesApp/Network/Endpoints/Protocols/Endpoint.swift
@@ -1,0 +1,32 @@
+//
+//  Endpoint.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+/// A protocol that represents an API endpoint definition.
+///
+/// Types conforming to this protocol define how a specific API request should be built,
+/// including the HTTP method, path, and parameters. The expected response type must conform to `Decodable`.
+///
+/// 🔧 **Future Improvements:**
+/// - Add support for custom headers, e.g., for access tokens or content-type overrides.
+/// - Allow optional configuration for timeout, caching policy, or other `URLRequest` properties.
+protocol Endpoint {
+
+  /// The type expected to be returned from the request, which must conform to `Decodable`.
+  associatedtype Response: Decodable
+
+  /// The HTTP method to use (e.g., `.get`, `.post`, `.delete`, `.put`).
+  var method: HTTPMethod { get }
+
+  /// The relative path to be appended to the base URL (e.g., `"classes"` or `"saved_classes"`).
+  var path: String { get }
+
+  /// Optional request parameters.
+  ///
+  /// For GET/DELETE requests, these are added as query parameters.
+  /// For POST/PUT requests, these are encoded as a JSON body.
+  var parameters: [String: Any?]? { get }
+}

--- a/ClassesApp/Network/HTTPMethod.swift
+++ b/ClassesApp/Network/HTTPMethod.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPMethod.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+enum HTTPMethod: String {
+  case post = "POST"
+  case get = "GET"
+  case delete = "DELETE"
+  case put = "PUT"
+}


### PR DESCRIPTION
In this PR, we introduce a basic networking layer to handle API communication in a centralized and reusable way.

The APIClient is responsible for building requests, handling query and body parameters, decoding responses, and reporting common network-related errors.

This setup will allow us to expand easily as the app grows, adding features like custom headers, advanced error handling, or support for multiple environments.