### PR TITLE
feat: add model layer

### DIFF
--- a/ClassesApp/Models/Class.swift
+++ b/ClassesApp/Models/Class.swift
@@ -1,0 +1,19 @@
+//
+//  Class.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+struct Class: Decodable {
+  let title: String
+  let slug: String
+  let imageURL: String
+  var favorite: Bool = false
+  
+  enum CodingKeys: String, CodingKey {
+    case title
+    case slug
+    case imageURL = "image_url"
+  }
+}

--- a/ClassesApp/Models/EmptyResponse.swift
+++ b/ClassesApp/Models/EmptyResponse.swift
@@ -1,0 +1,8 @@
+//
+//  EmptyResponse.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+struct EmptyResponse: Decodable {}

--- a/ClassesApp/Network/Endpoints/Implementations/ClassesEndpoint.swift
+++ b/ClassesApp/Network/Endpoints/Implementations/ClassesEndpoint.swift
@@ -1,0 +1,49 @@
+//
+//  Classes.swift
+//  ClassesApp
+//
+//  Created by Tarek Radovan on 21/05/2025.
+//
+
+struct Classes {}
+
+extension Classes {
+  struct GetAll: Endpoint {
+    typealias Response = [Class]
+    
+    var method: HTTPMethod { .get }
+    var path: String { "classes" }
+    var parameters: [String : Any?]? { nil }
+  }
+
+  struct GetFavs: Endpoint {
+    typealias Response = [String]
+    var method: HTTPMethod { .get }
+    var path: String { "saved_classes" }
+    var parameters: [String : Any?]? { nil }
+  }
+
+  struct DeleteFromFavorites: Endpoint {
+    
+    typealias Response = EmptyResponse
+    
+    let slug: String
+    
+    var method: HTTPMethod { .delete }
+    var path: String { "classes" }
+    var parameters: [String : Any?]? {
+      [ "slug": slug ]
+    }
+  }
+
+  struct AddToFavorites: Endpoint {
+    typealias Response = EmptyResponse
+    let slug: String
+
+    var method: HTTPMethod { .post }
+    var path: String { "classes" }
+    var parameters: [String: Any?]? {
+      [ "slug": slug ]
+    }
+  }
+}


### PR DESCRIPTION
Adds base response models to support API integration.
	•	Class: represents course data returned from the /classes and /saved_classes endpoints
	•	EmptyResponse: used for endpoints that return no body (POST/DELETE)

This sets up the foundation for response decoding and UI binding.